### PR TITLE
Fix issue where Nose was interpreting the test model as a test

### DIFF
--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,7 +1,10 @@
 import datetime
 
 from django.db import models
+from nose.tools import nottest
 
+
+@nottest
 class TestObj(models.Model):
     char_value = models.CharField(max_length=100, default='')
     int_value = models.IntegerField(default=0)

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ exclude = migrations
 
 [tox]
 install_command = pip install {opts} {packages}
-envlist = clean,py27-{1.7,1.8},stats
+envlist = clean,py27-{1.7,1.8,1.9},stats
 
 [testenv]
 usedevelop = True
@@ -15,6 +15,7 @@ deps =
   -r{toxinidir}/requirements-test.txt
   1.7: Django>=1.7,<1.8
   1.8: Django>=1.8,<1.9
+  1.9: Django>=1.9,<1.10
 
 # `clean` and `stats` targets are based on the coverage setup at
 # http://schinckel.net/2014/07/28/tox-and-coverage.py/


### PR DESCRIPTION
Followup to #5. This fixes a weird incompatibility with nose and Django 1.9. Nose was interpreting the `TestObj` model as a test because it starts with the word `Test`. This gets the build passing on Django 1.9 by marking it as `@nottest`.