### PR TITLE
Add tests for related behavior

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Preston Holmes
+Lucas Wiman

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -30,6 +30,8 @@ class P(Q):
 
     # allow the use of the 'in' operator for membership testing
     def __contains__(self, obj):
+        # TODO: This overrides Q's __contains__ method. It should only have
+        # the custom behavior for non-Node objects.
         return self.eval(obj)
 
     def eval(self, instance):

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -159,7 +159,16 @@ class LookupExpression(object):
         return lookup_field.day == self.value
 
     def _week_day(self, lookup_model, lookup_field):
-        return lookup_field.weekday() == self.value
+        # Counterintuitively, the __week_day lookup does not use the .weekday()
+        # python method, but instead some custom django weekday thing
+        # (Sunday=1 to Saturday=7). This is equivalent to:
+        # (isoweekday mod 7) + 1.
+        # https://docs.python.org/2/library/datetime.html#datetime.date.isoweekday
+        #
+        # See docs at https://docs.djangoproject.com/en/dev/ref/models/querysets/#week-day
+        # and https://code.djangoproject.com/ticket/10345 for additional
+        # discussion.
+        return (lookup_field.isoweekday() % 7) + 1 == self.value
 
     def _isnull(self, lookup_model, lookup_field):
         if self.value:

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -38,7 +38,11 @@ class P(Q):
         """
         evaluators = {"AND": all, "OR": any}
         evaluator = evaluators[self.connector]
-        return (evaluator(c.eval(instance) for c in eval_wrapper(self.children)))
+        ret = evaluator(c.eval(instance) for c in eval_wrapper(self.children))
+        if self.negated:
+            return not ret
+        else:
+            return ret
 
     def to_identifier(self):
         s = ""

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -17,6 +17,7 @@ brown
 black
 white""".split('\n')
 
+
 def make_test_objects():
     made = []
 
@@ -29,6 +30,7 @@ def make_test_objects():
         t.save()
         made.append(t)
 
+
 class RelationshipFollowTest(TestCase):
     def setUp(self):
         make_test_objects()
@@ -40,6 +42,7 @@ class RelationshipFollowTest(TestCase):
         p2 = P(parent__parent__int_value__gt=10)
         obj = TestObj.objects.filter(parent__parent__int_value__gt=10)[0]
         self.assertTrue(p2.eval(obj))
+
 
 class ComparisonFunctionsTest(TestCase):
 
@@ -161,4 +164,3 @@ class GroupTest(TestCase):
         por2 = p2 | p3
         self.assertTrue(por1.eval(self.testobj))
         self.assertFalse(por2.eval(self.testobj))
-

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -1,6 +1,8 @@
 from datetime import date
 from random import choice, random
+from unittest import expectedFailure
 
+from django.test import skipIfDBFeature
 from django.test import TestCase
 from nose.tools import assert_equal
 
@@ -19,6 +21,19 @@ violet
 brown
 black
 white""".split('\n')
+
+
+class OrmP(P):
+    """
+    Implementation of P semantics that asserts the ORM and P have the same
+    semantics.
+    """
+    def eval(self, instance):
+        queryset = type(instance)._default_manager.filter(self, pk=instance.pk)
+        orm_value = queryset.exists()
+        super_value = super(OrmP, self).eval(instance)
+        assert_equal(orm_value, super_value)
+        return super_value
 
 
 def assert_universal_invariants(predicate, instance):
@@ -51,26 +66,27 @@ class RelationshipFollowTest(TestCase):
 
     def test_random_follow_relationship(self):
         make_test_objects()
-        p1 = P(parent__int_value__gt=10)
+        p1 = OrmP(parent__int_value__gt=10)
         obj = TestObj.objects.filter(parent__int_value__gt=10)[0]
         self.assertTrue(p1.eval(obj))
-        p2 = P(parent__parent__int_value__gt=10)
+        p2 = OrmP(parent__parent__int_value__gt=10)
         obj = TestObj.objects.filter(parent__parent__int_value__gt=10)[0]
         self.assertTrue(p2.eval(obj))
 
+    @expectedFailure  # FIXME: Bug with reverse relationships.
     def test_children_relationship_single(self):
         parent = TestObj.objects.create(int_value=100)
         TestObj.objects.bulk_create([
             TestObj(int_value=i, parent=parent) for i in range(3)
         ])
-        self.assertIn(parent, TestObj.objects.filter(P(children__int_value=2)))
-        pred = P(children__int_value=2)
-        pred.foo = True
+        self.assertIn(parent, TestObj.objects.filter(OrmP(children__int_value=2)))
+        pred = OrmP(children__int_value=2)
         self.assertIn(parent, pred)
-        assert_universal_invariants(P(children__int_value=2), parent)
+        assert_universal_invariants(OrmP(children__int_value=2), parent)
 
 
 class TestLookupExpression(TestCase):
+    @expectedFailure  # FIXME: Bug with reverse relationships.
     def test_get_field_on_reverse_foreign_key(self):
         parent = TestObj.objects.create(int_value=100)
         TestObj.objects.bulk_create([
@@ -84,94 +100,102 @@ class TestLookupExpression(TestCase):
 class ComparisonFunctionsTest(TestCase):
 
     def setUp(self):
-        self.testobj = TestObj(
+        self.testobj = TestObj.objects.create(
                 char_value="hello world",
                 int_value=50,
                 date_value=date.today())
 
     def test_exact(self):
-        self.assertTrue(P(char_value__exact='hello world').eval(self.testobj))
-        self.assertTrue(P(char_value='hello world').eval(self.testobj))
-        self.assertFalse(P(char_value='Hello world').eval(self.testobj))
-        self.assertFalse(P(char_value='hello worl').eval(self.testobj))
+        self.assertTrue(OrmP(char_value__exact='hello world').eval(self.testobj))
+        self.assertTrue(OrmP(char_value='hello world').eval(self.testobj))
+        self.assertFalse(OrmP(char_value='hello worl').eval(self.testobj))
 
     def test_iexact(self):
-        self.assertTrue(P(char_value__iexact='heLLo World').eval(self.testobj))
-        self.assertFalse(P(char_value__iexact='hello worl').eval(self.testobj))
+        self.assertTrue(OrmP(char_value__iexact='heLLo World').eval(self.testobj))
+        self.assertFalse(OrmP(char_value__iexact='hello worl').eval(self.testobj))
 
     def test_contains(self):
-        self.assertTrue(P(char_value__contains='hello').eval(self.testobj))
-        self.assertFalse(P(char_value__contains='foobar').eval(self.testobj))
+        self.assertTrue(OrmP(char_value__contains='hello').eval(self.testobj))
+        self.assertFalse(OrmP(char_value__contains='foobar').eval(self.testobj))
 
     def test_icontains(self):
-        self.assertTrue(P(char_value__icontains='heLLo').eval(self.testobj))
+        self.assertTrue(OrmP(char_value__icontains='heLLo').eval(self.testobj))
+
+    @skipIfDBFeature('has_case_insensitive_like')
+    def test_case_sensitive_lookups_are_case_sensitive(self):
+        self.assertFalse(OrmP(char_value='Hello world').eval(self.testobj))
+        self.assertFalse(OrmP(char_value__contains='heLLo').eval(self.testobj))
+        self.assertFalse(OrmP(char_value__startswith='Hello').eval(self.testobj))
+        self.assertFalse(OrmP(char_value__endswith='World').eval(self.testobj))
 
     def test_gt(self):
-        self.assertTrue(P(int_value__gt=20).eval(self.testobj))
-        self.assertFalse(P(int_value__gt=80).eval(self.testobj))
-        self.assertTrue(P(int_value__gt=20.0).eval(self.testobj))
-        self.assertFalse(P(int_value__gt=80.0).eval(self.testobj))
-        self.assertFalse(P(int_value__gt=50).eval(self.testobj))
+        self.assertTrue(OrmP(int_value__gt=20).eval(self.testobj))
+        self.assertFalse(OrmP(int_value__gt=80).eval(self.testobj))
+        self.assertTrue(OrmP(int_value__gt=20.0).eval(self.testobj))
+        self.assertFalse(OrmP(int_value__gt=80.0).eval(self.testobj))
+        self.assertFalse(OrmP(int_value__gt=50).eval(self.testobj))
 
     def test_gte(self):
-        self.assertTrue(P(int_value__gte=20).eval(self.testobj))
-        self.assertTrue(P(int_value__gte=50).eval(self.testobj))
+        self.assertTrue(OrmP(int_value__gte=20).eval(self.testobj))
+        self.assertTrue(OrmP(int_value__gte=50).eval(self.testobj))
 
     def test_lt(self):
-        self.assertFalse(P(int_value__lt=20).eval(self.testobj))
-        self.assertTrue(P(int_value__lt=80).eval(self.testobj))
-        self.assertFalse(P(int_value__lt=20.0).eval(self.testobj))
-        self.assertTrue(P(int_value__lt=80.0).eval(self.testobj))
-        self.assertFalse(P(int_value__lt=50).eval(self.testobj))
+        self.assertFalse(OrmP(int_value__lt=20).eval(self.testobj))
+        self.assertTrue(OrmP(int_value__lt=80).eval(self.testobj))
+        self.assertFalse(OrmP(int_value__lt=20.0).eval(self.testobj))
+        self.assertTrue(OrmP(int_value__lt=80.0).eval(self.testobj))
+        self.assertFalse(OrmP(int_value__lt=50).eval(self.testobj))
 
     def test_lte(self):
-        self.assertFalse(P(int_value__lte=20).eval(self.testobj))
-        self.assertTrue(P(int_value__lte=50).eval(self.testobj))
+        self.assertFalse(OrmP(int_value__lte=20).eval(self.testobj))
+        self.assertTrue(OrmP(int_value__lte=50).eval(self.testobj))
 
     def test_startswith(self):
-        self.assertTrue(P(char_value__startswith='hello').eval(self.testobj))
-        self.assertFalse(P(char_value__startswith='world').eval(self.testobj))
-        self.assertFalse(P(char_value__startswith='Hello').eval(self.testobj))
+        self.assertTrue(OrmP(char_value__startswith='hello').eval(self.testobj))
+        self.assertFalse(OrmP(char_value__startswith='world').eval(self.testobj))
 
     def test_istartswith(self):
-        self.assertTrue(P(char_value__istartswith='heLLo').eval(self.testobj))
-        self.assertFalse(P(char_value__startswith='world').eval(self.testobj))
+        self.assertTrue(OrmP(char_value__istartswith='heLLo').eval(self.testobj))
+        self.assertFalse(OrmP(char_value__startswith='world').eval(self.testobj))
 
     def test_endswith(self):
-        self.assertFalse(P(char_value__endswith='hello').eval(self.testobj))
-        self.assertTrue(P(char_value__endswith='world').eval(self.testobj))
-        self.assertFalse(P(char_value__endswith='World').eval(self.testobj))
+        self.assertFalse(OrmP(char_value__endswith='hello').eval(self.testobj))
+        self.assertTrue(OrmP(char_value__endswith='world').eval(self.testobj))
 
     def test_iendswith(self):
-        self.assertFalse(P(char_value__iendswith='hello').eval(self.testobj))
-        self.assertTrue(P(char_value__iendswith='World').eval(self.testobj))
+        self.assertFalse(OrmP(char_value__iendswith='hello').eval(self.testobj))
+        self.assertTrue(OrmP(char_value__iendswith='World').eval(self.testobj))
 
     def test_dates(self):
         today = date.today()
-        self.assertTrue(P(date_value__year=today.year).eval(self.testobj))
-        self.assertTrue(P(date_value__month=today.month).eval(self.testobj))
-        self.assertTrue(P(date_value__day=today.day).eval(self.testobj))
-        self.assertTrue(P(date_value__week_day=today.weekday()).eval(self.testobj))
+        self.assertTrue(OrmP(date_value__year=today.year).eval(self.testobj))
+        self.assertTrue(OrmP(date_value__month=today.month).eval(self.testobj))
+        self.assertTrue(OrmP(date_value__day=today.day).eval(self.testobj))
 
-        self.assertFalse(P(date_value__year=today.year + 1).eval(self.testobj))
-        self.assertFalse(P(date_value__month=today.month + 1).eval(self.testobj))
-        self.assertFalse(P(date_value__day=today.day + 1).eval(self.testobj))
-        self.assertFalse(P(date_value__week_day=today.weekday() + 1).eval(self.testobj))
+        orm_week_day = today.isoweekday() % 7 + 1
+
+        self.assertTrue(
+            OrmP(date_value__week_day=orm_week_day).eval(self.testobj))
+
+        self.assertFalse(OrmP(date_value__year=today.year + 1).eval(self.testobj))
+        self.assertFalse(OrmP(date_value__month=today.month + 1).eval(self.testobj))
+        self.assertFalse(OrmP(date_value__day=today.day + 1).eval(self.testobj))
+        self.assertFalse(P(date_value__week_day=orm_week_day + 1).eval(self.testobj))
 
     def test_null(self):
-        self.assertTrue(P(parent__isnull=True).eval(self.testobj))
-        self.assertFalse(P(parent__isnull=False).eval(self.testobj))
+        self.assertTrue(OrmP(parent__isnull=True).eval(self.testobj))
+        self.assertFalse(OrmP(parent__isnull=False).eval(self.testobj))
 
     def test_regex(self):
-        self.assertTrue(P(char_value__regex='hel*o').eval(self.testobj))
-        self.assertFalse(P(char_value__regex='Hel*o').eval(self.testobj))
+        self.assertTrue(OrmP(char_value__regex='hel*o').eval(self.testobj))
+        self.assertFalse(OrmP(char_value__regex='Hel*o').eval(self.testobj))
 
     def test_iregex(self):
-        self.assertTrue(P(char_value__iregex='Hel*o').eval(self.testobj))
+        self.assertTrue(OrmP(char_value__iregex='Hel*o').eval(self.testobj))
 
     def test_in_operator(self):
-        p = P(int_value__lte=50)
-        p2 = P(int_value__lt=10)
+        p = OrmP(int_value__lte=50)
+        p2 = OrmP(int_value__lt=10)
         self.assertTrue(self.testobj in p)
         self.assertFalse(self.testobj in p2)
 
@@ -179,29 +203,29 @@ class ComparisonFunctionsTest(TestCase):
 class TestBooleanOperations(TestCase):
 
     def setUp(self):
-        self.testobj = TestObj(
+        self.testobj = TestObj.objects.create(
                 char_value="hello world",
                 int_value=50,
                 date_value=date.today())
 
     def test_and(self):
-        p1 = P(char_value__contains='hello')
-        p2 = P(int_value=50)
-        p3 = P(int_value__lt=20)
+        p1 = OrmP(char_value__contains='hello')
+        p2 = OrmP(int_value=50)
+        p3 = OrmP(int_value__lt=20)
         pand1 = p1 & p2
         pand2 = p2 & p3
         self.assertTrue(pand1.eval(self.testobj))
         self.assertFalse(pand2.eval(self.testobj))
 
     def test_or(self):
-        p1 = P(char_value__contains='hello', int_value=50)
-        p2 = P(int_value__gt=80)
-        p3 = P(int_value__lt=20)
+        p1 = OrmP(char_value__contains='hello', int_value=50)
+        p2 = OrmP(int_value__gt=80)
+        p3 = OrmP(int_value__lt=20)
         por1 = p1 | p2
         por2 = p2 | p3
         self.assertTrue(por1.eval(self.testobj))
         self.assertFalse(por2.eval(self.testobj))
 
     def test_not(self):
-        self.assertIn(self.testobj, P(int_value=self.testobj.int_value))
-        self.assertNotIn(self.testobj, ~P(int_value=self.testobj.int_value))
+        self.assertIn(self.testobj, OrmP(int_value=self.testobj.int_value))
+        self.assertNotIn(self.testobj, ~OrmP(int_value=self.testobj.int_value))

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from nose.tools import assert_equal
 
 from predicate import P
+from predicate.predicate import LookupExpression
 from models import TestObj
 
 
@@ -69,6 +70,15 @@ class RelationshipFollowTest(TestCase):
         assert_universal_invariants(P(children__int_value=2), parent)
 
 
+class TestLookupExpression(TestCase):
+    def test_get_field_on_reverse_foreign_key(self):
+        parent = TestObj.objects.create(int_value=100)
+        TestObj.objects.bulk_create([
+            TestObj(int_value=i, parent=parent) for i in range(3)
+        ])
+        expr = LookupExpression(('children__int_value', 2))
+        lookup_model, lookup_field, lookup_type = expr.get_field(parent)
+        self.assertEqual(set(lookup_field), set(range(3)))
 
 
 class ComparisonFunctionsTest(TestCase):


### PR DESCRIPTION
cc @ptone This Pull Request updates the tests significantly and fixes two bugs.

## Bugs
- Negation was unhandled. This is now covered by a test, and the behavior of `eval` has been corrected.
- The `__week_day` lookup does not use python's `weekday()` or `isoweekday()`, but a custom 1-indexed week that starts on a Sunday. This bug was discovered by the ORM concordance updates below, and has been corrected.

## Test Updates
- Added an `OrmP` class which behaves like `P`, but checks concordance with the ORM database backend. When `eval` is called, it makes what should be an isomorphic call to the ORM backend to see if a matching database row exists. Usages of `P` in the tests were replaced by this class, which uncovered two bugs:
  - The `week_day` weirdness above.
  - In SQLite, `LIKE` is case insensitive by default. It can be made case sensitive, but only on a connection level. I think this is one case where the database is basically "wrong", and there's no use emulating it in predicate evaluation. There are several Django tickets where this answer is given when people have reported bugs related to this.
- Added a few tests related to reverse relations that fail. I marked them as expected failures with FIXMEs attached.