### PR TITLE
Add tox targets for postgres

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@
 coverage
 django-nose==1.4.2
 nose==1.3.7
+psycopg2

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -1,4 +1,4 @@
-# Django settings for testapp project.
+import os
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
@@ -9,16 +9,28 @@ ADMINS = (
 
 MANAGERS = ADMINS
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'test.db',                      # Or path to database file if using sqlite3.
-        'USER': '',                      # Not used with sqlite3.
-        'PASSWORD': '',                  # Not used with sqlite3.
-        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
+_BACKEND = os.environ.get("DB_BACKEND", "sqlite3")
+
+if _BACKEND == 'sqlite3':
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': 'test.db',
+            'USER': '',
+            'PASSWORD': '',
+            'HOST': '',
+            'PORT': '',
+        }
     }
-}
+elif _BACKEND == 'postgresql_psycopg2':
+    DATABASES = {
+        'default': {
+            'NAME': 'predicatedb',
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'USER': 'django',
+            'PASSWORD': 'secret',
+        },
+    }
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ exclude = migrations
 
 [tox]
 install_command = pip install {opts} {packages}
-envlist = clean,py27-{1.7,1.8,1.9},stats
+envlist = clean,py27-{1.7,1.8,1.9}-{postgres,sqlite},stats
 
 [testenv]
 usedevelop = True
@@ -16,6 +16,9 @@ deps =
   1.7: Django>=1.7,<1.8
   1.8: Django>=1.8,<1.9
   1.9: Django>=1.9,<1.10
+setenv =
+  sqlite: DB_BACKEND=sqlite3
+  postgres: DB_BACKEND=postgresql_psycopg2
 
 # `clean` and `stats` targets are based on the coverage setup at
 # http://schinckel.net/2014/07/28/tox-and-coverage.py/


### PR DESCRIPTION
This adds tox environments for the postgres backend. Since this has case-sensitive `LIKE`, the test suite now covers the `__exact` and `__contains` lookups 