### PR TITLE
Add several extra kinds of models and associated tests.

### DIFF
--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -10,6 +10,7 @@ QUERY_TERMS = set([
     'month', 'day', 'week_day', 'isnull', 'search', 'regex', 'iregex',
 ])
 
+
 def eval_wrapper(children):
     """
     generator to yield child nodes, or to wrap filter expressions
@@ -19,6 +20,7 @@ def eval_wrapper(children):
             yield child
         elif isinstance(child, tuple) and len(child) == 2:
             yield LookupExpression(child)
+
 
 class P(Q):
     """
@@ -53,7 +55,8 @@ class P(Q):
                 s += c.to_identifier()
             else:
                 s += ''.join([str(val) for val in c])
-        return s.replace('_','')
+        return s.replace('_', '')
+
 
 class LookupExpression(object):
     """
@@ -188,5 +191,3 @@ class LookupExpression(object):
 
     def _iregex(self, lookup_model, lookup_field):
         return bool(re.search(self.value, lookup_field, flags=re.I))
-
-

--- a/runtests.py
+++ b/runtests.py
@@ -5,7 +5,6 @@ import sys
 os.environ.setdefault("DJANGO_SETTINGS_MODULE",
                       "tests.testapp.settings")
 
-from django.conf import settings
 from django_nose import NoseTestSuiteRunner
 
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -3,11 +3,35 @@ import datetime
 from django.db import models
 from nose.tools import nottest
 
-
-@nottest
-class TestObj(models.Model):
+class Base(models.Model):
+    class Meta:
+        abstract = True
     char_value = models.CharField(max_length=100, default='')
     int_value = models.IntegerField(default=0)
     date_value = models.DateField(default=datetime.date.today)
-    parent = models.ForeignKey('self', related_name='children', null=True)
+    datetime_value = models.DateTimeField(default=datetime.datetime.now)
 
+
+@nottest
+class TestObj(Base):
+    parent = models.ForeignKey('self', related_name='children', null=True)
+    m2ms = models.ManyToManyField(
+        'testapp.M2MModel', related_name='test_objs')
+
+
+class M2MModel(Base):
+    pass
+
+
+class OneToOneModel(Base):
+    test_obj = models.OneToOneField(
+        TestObj, null=True)
+
+
+class CustomRelatedNameOneToOneModel(Base):
+    test_obj = models.OneToOneField(
+        TestObj, related_name='custom_one_to_one', null=True)
+
+
+class ForeignKeyModel(Base):
+    test_obj = models.ForeignKey(TestObj, null=True)


### PR DESCRIPTION
Adds a bunch of failing tests exhibiting bugs.

## Tested conditions
- A bunch of direct and reverse relationships. Marked as expected failures with FIXMEs.
- Test that date/datetime casting doesn't cause a failure. Django's ORM will correctly handle comparisons between a `DateTimeField` and lookup on a date. The test currently fails with `TypeError: can't compare datetime.datetime to datetime.date`. Marked as an expected failure with a FIXME.
- Test the `__in` lookup, since this was not covered by the test suite. This test passes, and was just added for completeness.
- Test using an `__in` lookup with a `ValuesListQuerySet`. (Fails on `pk` not being a field.)
- Test that joint conditions which induce only one join in the SQL query should only match if on the same row. (Currently fails because of other broken things, but I think this will be tricky to get right in reworking the `get_field` logic.)