### PR TITLE
Testconfig

### DIFF
--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -69,7 +69,7 @@ class LookupExpression(object):
         self.field = None
 
     def get_field(self, instance):
-        lookup_type = 'exact' # Default lookup type
+        lookup_type = 'exact'  # Default lookup type
         parts = self.lookup.split(LOOKUP_SEP)
         num_parts = len(parts)
         if (len(parts) > 1 and parts[-1] in QUERY_TERMS):
@@ -87,13 +87,13 @@ class LookupExpression(object):
                 # to continue traversing relations.
                 if (counter + 1) < num_parts:
                     try:
-                        dummy = lookup_model._meta.get_field(field_name).rel.to
-                        lookup_model = lookup_field
-                        # print lookup_model
+                        lookup_model._meta.get_field(field_name).rel.to
                     except AttributeError:
                         # # Not a related field. Bail out.
                         lookup_type = parts.pop()
                         return (lookup_model, lookup_field, lookup_type)
+                    else:
+                        lookup_model = lookup_field
         else:
             return (instance, getattr(instance, parts[0]), lookup_type)
 
@@ -175,9 +175,9 @@ class LookupExpression(object):
 
     def _isnull(self, lookup_model, lookup_field):
         if self.value:
-            return lookup_field == None
+            return lookup_field is None
         else:
-            return lookup_field != None
+            return lookup_field is not None
 
     def _search(self, lookup_model, lookup_field):
         return self._contains(lookup_model, lookup_field)

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -3,6 +3,7 @@ import datetime
 from django.db import models
 from nose.tools import nottest
 
+
 class Base(models.Model):
     class Meta:
         abstract = True

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
@@ -10,12 +11,13 @@ ADMINS = (
 MANAGERS = ADMINS
 
 _BACKEND = os.environ.get("DB_BACKEND", "sqlite3")
+_ENVNAME = re.sub(r'\W', '', os.environ.get("TOXENV", ""))
 
 if _BACKEND == 'sqlite3':
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': 'test.db',
+            'NAME': 'test%s.db' % _ENVNAME,
             'USER': '',
             'PASSWORD': '',
             'HOST': '',
@@ -25,7 +27,7 @@ if _BACKEND == 'sqlite3':
 elif _BACKEND == 'postgresql_psycopg2':
     DATABASES = {
         'default': {
-            'NAME': 'predicatedb',
+            'NAME': 'predicatedb%s' % _ENVNAME,
             'ENGINE': 'django.db.backends.postgresql_psycopg2',
             'USER': 'django',
             'PASSWORD': 'secret',

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -11,6 +11,9 @@ ADMINS = (
 MANAGERS = ADMINS
 
 _BACKEND = os.environ.get("DB_BACKEND", "sqlite3")
+
+# Namespace test database by the tox environment to allow detox to run tests
+# in parallel.
 _ENVNAME = re.sub(r'\W', '', os.environ.get("TOXENV", ""))
 
 if _BACKEND == 'sqlite3':

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [flake8]
-exclude = migrations
+exclude = migrations,settings.py
+max-line-length = 100
+
 
 [tox]
 install_command = pip install {opts} {packages}
-envlist = clean,py27-{1.7,1.8,1.9}-{postgres,sqlite},stats
+envlist = lint,clean,py27-{1.7,1.8,1.9}-{postgres,sqlite},stats
 
 [testenv]
 usedevelop = True
@@ -32,3 +34,9 @@ commands=
   coverage combine
   coverage report
   coverage html
+
+[testenv:lint]
+deps =
+  flake8
+commands =
+  flake8 predicate/ tests

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
   1.8: Django>=1.8,<1.9
   1.9: Django>=1.9,<1.10
 setenv =
+  TOXENV={envname}
   sqlite: DB_BACKEND=sqlite3
   postgres: DB_BACKEND=postgresql_psycopg2
 


### PR DESCRIPTION
This PR updates the test configuration as follows:
- Added a lint target using `flake8` with a max line length of 100 characters. Fixed the linting errors.
- Inject the tox environment into the database name when runnning tests so the tests can be run in parallel. This reduced build time from 88 seconds to 12 seconds. Combining coverage between the different environments doesn't work correctly when the tests are run with detox.