### PR TITLE
Fix relation following

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs/_build
 test.db
 .tox
 /htmlcov
+/dist

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -1,6 +1,6 @@
 import re
-from itertools import chain
 
+import django
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.query_utils import Q
 
@@ -76,8 +76,12 @@ class LookupExpression(object):
             if obj is None:
                 values.append(None)
                 continue
-            field = obj._meta.get_field(lookup_name)
-            direct = not field.auto_created or field.concrete
+            if django.VERSION < (1, 8):
+                field, model, direct,  m2m = obj._meta.get_field_by_name(
+                    lookup_name)
+            else:
+                field = obj._meta.get_field(lookup_name)
+                direct = not field.auto_created or field.concrete
             accessor = lookup_name if direct else field.get_accessor_name()
             try:
                 result = getattr(obj, accessor)

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -2,6 +2,8 @@ import re
 
 import django
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Manager
+from django.db.models import QuerySet
 from django.db.models.query_utils import Q
 
 LOOKUP_SEP = '__'
@@ -88,7 +90,7 @@ class LookupExpression(object):
             except ObjectDoesNotExist:
                 values.append(None)
             else:
-                if hasattr(result, 'all'):
+                if isinstance(result, (QuerySet, Manager)):
                     values.extend(result.all())
                 else:
                     values.append(result)

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -78,7 +78,6 @@ class RelationshipFollowTest(TestCase):
         obj = TestObj.objects.filter(parent__parent__int_value__gt=10)[0]
         self.assertTrue(p2.eval(obj))
 
-    @expectedFailure  # FIXME: Bug with reverse relationships.
     def test_children_relationship_single(self):
         parent = TestObj.objects.create(int_value=100)
         TestObj.objects.bulk_create([
@@ -89,7 +88,6 @@ class RelationshipFollowTest(TestCase):
         self.assertIn(parent, pred)
         assert_universal_invariants(OrmP(children__int_value=2), parent)
 
-    @expectedFailure  # FIXME: Bug with reverse relationships.
     def test_direct_one_to_one_relationships(self):
         test_obj = TestObj.objects.create(int_value=1)
         other_test_obj = TestObj.objects.create(int_value=2)
@@ -102,7 +100,6 @@ class RelationshipFollowTest(TestCase):
         self.assertNotIn(one_to_one, OrmP(test_obj=other_test_obj))
         self.assertNotIn(one_to_one, OrmP(test_obj__int_value=2))
 
-    @expectedFailure  # FIXME: Bug with reverse relationships.
     def test_reverse_one_to_one_relationships(self):
         test_obj = TestObj.objects.create()
         one_to_one = OneToOneModel.objects.create(
@@ -115,7 +112,6 @@ class RelationshipFollowTest(TestCase):
         self.assertIn(test_obj, OrmP(onetoonemodel=one_to_one))
         self.assertIn(test_obj, OrmP(onetoonemodel__int_value=10))
 
-    @expectedFailure  # FIXME: Bug with reverse relationships.
     def test_reverse_one_to_one_relationships_custom_related_name(self):
         test_obj = TestObj.objects.create()
         custom_one_to_one = CustomRelatedNameOneToOneModel.objects.create(
@@ -129,7 +125,6 @@ class RelationshipFollowTest(TestCase):
         self.assertIn(test_obj, OrmP(custom_one_to_one=custom_one_to_one))
         self.assertIn(test_obj, OrmP(custom_one_to_one__int_value=10))
 
-    @expectedFailure  # FIXME: Bug with following direct relationships.
     def test_foreign_key_default_name(self):
         test_obj = TestObj.objects.create(int_value=20)
         fkey = ForeignKeyModel.objects.create(test_obj=test_obj)
@@ -137,7 +132,6 @@ class RelationshipFollowTest(TestCase):
         self.assertIn(fkey, OrmP(test_obj__int_value=20))
         self.assertNotIn(fkey, OrmP(test_obj__int_value=10))
 
-    @expectedFailure  # FIXME: Bug with reverse relationship names.
     def test_reverse_foreign_key_default_name(self):
         test_obj = TestObj.objects.create(int_value=20)
         fkey = ForeignKeyModel.objects.create(test_obj=test_obj, int_value=30)
@@ -147,7 +141,6 @@ class RelationshipFollowTest(TestCase):
         self.assertIn(test_obj, OrmP(foreignkeymodel__int_value=30))
         self.assertNotIn(test_obj, OrmP(foreignkeymodel=other_fkey))
 
-    @expectedFailure  # FIXME: Bug with ManyToManyFields.
     def test_m2m(self):
         test_obj = TestObj.objects.create(int_value=20)
         m2m = test_obj.m2ms.create(int_value=10)
@@ -187,7 +180,6 @@ class RelationshipFollowTest(TestCase):
 
 
 class TestLookupExpression(TestCase):
-    @expectedFailure  # FIXME: Bug with reverse relationships.
     def test_get_field_on_reverse_foreign_key(self):
         parent = TestObj.objects.create(int_value=100)
         TestObj.objects.bulk_create([


### PR DESCRIPTION
This PR fixes most of the known bugs relating to following reverse relationships. The `get_field` method has been updated to return a list of values, and the `__lookup` methods have been updated to match if at least one returned row matches. This is closer to how the database process queries, where a query will match if at least on row in the join table matches all the conditions.

This does not fix the joint-condition test, which will require a more significant refactor.

## Todo in later PRs

- The `get_field_from_objs` method does not consider whether the database join is an outer join (so NULL values should be included) or an inner join (so NULL rows should be excluded from the returned list). This could use a failing test case exhibiting this behavior.
- The `get_field` methods and associated arguments should be renamed to reflect expected inputs and outputs.