### PR TITLE
Lookup Tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .coverage
+.coverage.*
 docs/_build
 *.egg-info
 test.db

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -24,6 +24,8 @@ def eval_wrapper(children):
             yield child
         elif isinstance(child, tuple) and len(child) == 2:
             yield LookupEvaluator(child)
+        else:
+            raise ValueError(child)
 
 
 class P(Q):

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -23,7 +23,7 @@ def eval_wrapper(children):
         if isinstance(child, P):
             yield child
         elif isinstance(child, tuple) and len(child) == 2:
-            yield LookupExpression(child)
+            yield LookupEvaluator(child)
 
 
 class P(Q):
@@ -53,7 +53,7 @@ class P(Q):
             return ret
 
 
-class LookupExpression(object):
+class LookupEvaluator(object):
     """
     A thin wrapper around a filter expression tuple of (lookup-type, value) to
     provide an eval method

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -1,12 +1,13 @@
+import itertools
 import re
 
 import django
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Manager
 from django.db.models import QuerySet
+from django.db.models.constants import LOOKUP_SEP
 from django.db.models.query_utils import Q
 
-LOOKUP_SEP = '__'
 
 QUERY_TERMS = set([
     'exact', 'iexact', 'contains', 'icontains', 'gt', 'gte', 'lt', 'lte', 'in',
@@ -223,3 +224,164 @@ class LookupEvaluator(object):
         return any(
             value is not None and regex.search(value)
             for value in values)
+
+
+class LookupComponent(str):
+    def __repr__(self):
+        return '{self.__class__.__name__}({repr})'.format(
+            self=self,
+            repr=super(LookupComponent, self).__repr__())
+
+    @classmethod
+    def parse(cls, lookup):
+        """
+        Parses a lookup__string into a list of LookupComponent objects.
+        """
+        if not lookup:  # Handle '' standing in for leaf components in lookups.
+            return []
+        return map(cls, lookup.split(LOOKUP_SEP))
+
+    def values_list(self, obj):
+        if obj is None:
+            return [None]
+        elif self == LookupComponent.EMPTY:
+            return [obj]
+        values = []
+        if django.VERSION < (1, 8):
+            field, model, direct,  m2m = obj._meta.get_field_by_name(self)
+        else:
+            field = obj._meta.get_field(self)
+            direct = not field.auto_created or field.concrete
+        accessor = self if direct else field.get_accessor_name()
+        try:
+            result = getattr(obj, accessor)
+        except ObjectDoesNotExist:
+            values.append(None)
+        else:
+            if isinstance(result, (QuerySet, Manager)):
+                values.extend(result.all())
+            else:
+                values.append(result)
+        return values
+
+
+LookupComponent.EMPTY = LookupComponent('')
+UNDEFINED = object()
+GET = object()
+
+
+class LookupNode(object):
+    def __init__(self, lookups=None):
+        lookups = lookups or {}
+        self.children = {}
+        if lookups is not None:
+            for lookup, value in lookups.viewitems():
+                self[lookup] = value
+
+    @property
+    def value(self):
+        return self.children.get(LookupComponent.EMPTY, UNDEFINED)
+
+    @value.setter
+    def value(self, value):
+        self.children[LookupComponent.EMPTY] = value
+
+    def __setitem__(self, lookup, value):
+        components = LookupComponent.parse(lookup)
+        cur = self
+        for component in components:
+            prev = cur
+            cur = cur.children.get(component)
+            if cur is None:
+                prev.children[component] = cur = LookupNode()
+        cur.value = value
+
+    def __getitem__(self, lookup):
+        components = LookupComponent.parse(lookup)
+        cur = self
+        for component in components:
+            cur = cur.children[component]
+        return cur
+
+    def iteritems(self, lookup_stack=None):
+        lookup_stack = [] if lookup_stack is None else lookup_stack
+        for component, node in self.children.viewitems():
+            if component == LookupComponent.EMPTY:
+                yield (LOOKUP_SEP.join(lookup_stack), self.value)
+            else:
+                lookup_stack.append(component)
+                for item in node.iteritems(lookup_stack=lookup_stack):
+                    yield item
+                lookup_stack.pop()
+
+    def to_dict(self):
+        return dict(self.iteritems())
+
+    def __repr__(self):
+        return 'LookupNode(lookups=%r)' % self.to_dict()
+
+    def eval(self, instance):
+        query_values_lookups = self.convert_to_query_values_node()
+        values = query_values_lookups.values(instance)
+        for node in values:
+            node_matches = True
+            for lookup, value in node.iteritems():
+                queries = self[lookup]
+                for query, query_value in queries.iteritems():
+                    if query == LookupComponent.EMPTY:
+                        # No query lookup was specified, so assume __exact
+                        query = 'exact'
+                    evaluator = LookupEvaluator((query, query_value))
+                    comparison_func = getattr(evaluator, '_' + query)
+                    if not comparison_func([value]):
+                        node_matches = False
+                        break
+                if not node_matches:
+                    break
+            if node_matches:
+                return True
+        return False
+
+    def convert_to_query_values_node(self):
+        """
+        Returns a version of self that has had all query lookup components
+        replaced by GET operations.
+
+        Used for evaluating predicates.
+        """
+        lookups = LookupNode()
+        for lookup, _ in self.iteritems():
+            parsed = LookupComponent.parse(lookup)
+            if parsed[-1].is_query:
+                parsed.pop()
+            lookups[LOOKUP_SEP.join(parsed)] = GET
+        return lookups
+
+    def values(self, obj):
+        """
+        Returns a list of LookupNode instances matching the GET lookups in self.
+        """
+        lookup2values = {}
+        for lookup, child in self.children.items():
+            lookup_objects = lookup.values_list(obj)
+            if lookup == LookupComponent.EMPTY:
+                child_values = lookup_objects
+            else:
+                child_values = []
+                for lookup_obj in lookup_objects:
+                    child_values.extend(child.values(lookup_obj))
+            lookup2values[lookup] = child_values
+
+        # Construct a cartesian product of all returned values. This
+        # corresponds to a database join among the lookups.
+        # TODO: Does this handle inner and outer joins properly?
+        children_iters = (
+            itertools.izip(itertools.repeat(lookup), values)
+            for lookup, values in lookup2values.items())
+        results = []
+        for child_product in itertools.product(*children_iters):
+            node = LookupNode()
+            for lookup, value in child_product:
+                node.children[lookup] = value
+            results.append(node)
+        return results

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -12,7 +12,6 @@ from predicate.predicate import GET
 from predicate.predicate import LookupComponent
 from predicate.predicate import LookupNode
 from predicate import P
-from predicate.predicate import LookupEvaluator
 from models import CustomRelatedNameOneToOneModel
 from models import ForeignKeyModel
 from models import M2MModel
@@ -154,7 +153,6 @@ class RelationshipFollowTest(TestCase):
         self.assertNotIn(test_obj, OrmP(m2ms=m2m2))
         self.assertNotIn(test_obj, OrmP(m2ms__int_value=30))
 
-    @expectedFailure
     def test_joint_conditions(self):
         """
         Test that joint conditions must be on the same aliased instance.
@@ -180,17 +178,6 @@ class RelationshipFollowTest(TestCase):
         self.assertIn(
             test_obj,
             OrmP(m2ms__int_value=10, m2ms__char_value='foo'))
-
-
-class TestLookupExpression(TestCase):
-    def test_get_field_on_reverse_foreign_key(self):
-        parent = TestObj.objects.create(int_value=100)
-        TestObj.objects.bulk_create([
-            TestObj(int_value=i, parent=parent) for i in range(3)
-        ])
-        expr = LookupEvaluator(('children__int_value', 2))
-        lookup_model, lookup_field, lookup_type = expr.get_field(parent)
-        self.assertEqual(set(lookup_field), set(range(3)))
 
 
 class ComparisonFunctionsTest(TestCase):

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 from nose.tools import assert_equal
 
 from predicate import P
-from predicate.predicate import LookupExpression
+from predicate.predicate import LookupEvaluator
 from models import CustomRelatedNameOneToOneModel
 from models import ForeignKeyModel
 from models import M2MModel
@@ -185,7 +185,7 @@ class TestLookupExpression(TestCase):
         TestObj.objects.bulk_create([
             TestObj(int_value=i, parent=parent) for i in range(3)
         ])
-        expr = LookupExpression(('children__int_value', 2))
+        expr = LookupEvaluator(('children__int_value', 2))
         lookup_model, lookup_field, lookup_type = expr.get_field(parent)
         self.assertEqual(set(lookup_field), set(range(3)))
 


### PR DESCRIPTION
This PR constructs a `LookupNode` class representing the graph structure of set of linear lookups.

For example, the lookups `foo__bar__value1=5, foo__bar__value2='something'` would be converted to SQL of the form:
```sql
SELECT ... FROM foo JOIN bar ... 
WHERE bar.value1=5 AND value2='something'
```
The previous behavior would check `value1` and `value2` on *any* of the matched rows *independently*, equivalent to a separate join for each condition on the relation:
```sql
SELECT ... FROM foo JOIN bar AS bar1 ... JOIN bar AS bar2 ...
WHERE bar1.value1=5 AND bar2.value2='something'
```
The new behavior traverses the lookup's tree structure, so the above would be converted to a tree, and conditions that must match on the same row of a join are matched jointly:
```
    +---+
    |foo|
    +-+-+
      |
      |
      |
      v
    +-+-+
    |bar+
    +---+-------------+
    |                 |
    |                 |
    v                 v
+---+------+      +---+----------------+
| value1=5 |      | value2='something' |
+----------+      +--------------------+
```

This also allows simulating `QuerySet.values(*lookups)` without issuing database queries queries, and means the `RelationshipFollowTest.test_joint_conditions` test now passes.

The code is still a lot more complicated than I'd like, so I intend to refactor and simplify it in following PRs. 