### PR TITLE
Fix date and pk casting

### DIFF
--- a/predicate/__init__.py
+++ b/predicate/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from .predicate import P
 
-__version__ = '0.1.1'
+__version__ = '1.0.0'
 __all__ = ['P']
 

--- a/predicate/lookup_utils.py
+++ b/predicate/lookup_utils.py
@@ -56,9 +56,6 @@ class Regex(LookupQueryEvaluator):
             rhs = re.escape(rhs)
         self.rhs = re.compile((self.template % rhs), flags=self.flags)
 
-    def compile_regex(self, rhs):
-        return re.compile(rhs)
-
 
 class StartsWith(LookupQueryEvaluator):
     evaluators = (NOT_NULL, (lambda lhs, rhs: lhs.startswith(rhs)))

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -89,7 +89,10 @@ class LookupComponent(str):
         elif self == LookupComponent.EMPTY:
             return [obj]
         values = []
-        if django.VERSION < (1, 8):
+        if self == 'pk':
+            field = obj._meta.pk
+            direct = True
+        elif django.VERSION < (1, 8):
             field, model, direct,  m2m = obj._meta.get_field_by_name(self)
         else:
             field = obj._meta.get_field(self)

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -352,6 +352,20 @@ class ComparisonFunctionsTest(TestCase):
         self.assertIn(
             self.testobj, OrmP(pk__in=pk_values_list))
 
+    def test_pk_casting_queryset(self):
+        qs = TestObj.objects.all()
+        self.assertIn(
+            self.testobj, TestObj.objects.filter(pk__in=qs))
+        self.assertIn(
+            self.testobj, OrmP(pk__in=qs))
+
+    def test_pk_casting_flat(self):
+        pk_values_list = TestObj.objects.values_list('pk', flat=True)
+        self.assertIn(
+            self.testobj, TestObj.objects.filter(pk__in=pk_values_list))
+        self.assertIn(
+            self.testobj, OrmP(pk__in=pk_values_list))
+
 
 class TestBooleanOperations(TestCase):
 

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -2,7 +2,6 @@ from datetime import date
 from datetime import datetime
 from datetime import timedelta
 from random import choice, random
-from unittest import expectedFailure
 
 from django.test import skipIfDBFeature
 from django.test import TestCase
@@ -343,8 +342,6 @@ class ComparisonFunctionsTest(TestCase):
         self.assertTrue(self.testobj in p)
         self.assertFalse(self.testobj in p2)
 
-    # FIXME: FieldDoesNotExist: TestObj has no field named 'pk'
-    @expectedFailure
     def test_pk_casting(self):
         pk_values_list = TestObj.objects.values_list('pk')
         self.assertIn(

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -220,7 +220,6 @@ class ComparisonFunctionsTest(TestCase):
         self.assertFalse(OrmP(int_value__gt=80.0).eval(self.testobj))
         self.assertFalse(OrmP(int_value__gt=50).eval(self.testobj))
 
-    @expectedFailure  # FIXME: fix datetime casting bugs.
     def test_datetime_cast(self):
         """
         Tests that the Django ORM casting rules are obeyed in filtering by

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -231,15 +231,54 @@ class ComparisonFunctionsTest(TestCase):
         self.assertIn(
             self.testobj,
             OrmP(datetime_value__gt=today - timedelta(days=1)))
+        self.assertIn(
+            self.testobj,
+            OrmP(datetime_value__gte=today - timedelta(days=1)))
+        self.assertNotIn(
+            self.testobj,
+            OrmP(datetime_value__lte=today - timedelta(days=1)))
+        self.assertNotIn(
+            self.testobj,
+            OrmP(datetime_value__lt=today - timedelta(days=1)))
+
         self.assertNotIn(
             self.testobj,
             OrmP(datetime_value__gt=today + timedelta(days=1)))
+        self.assertNotIn(
+            self.testobj,
+            OrmP(datetime_value__gte=today + timedelta(days=1)))
+        self.assertIn(
+            self.testobj,
+            OrmP(datetime_value__lte=today + timedelta(days=1)))
+        self.assertIn(
+            self.testobj,
+            OrmP(datetime_value__lt=today + timedelta(days=1)))
+
         self.assertIn(
             self.testobj,
             OrmP(date_value__gt=now - timedelta(days=1)))
+        self.assertIn(
+            self.testobj,
+            OrmP(date_value__gte=now - timedelta(days=1)))
+        self.assertNotIn(
+            self.testobj,
+            OrmP(date_value__lte=now - timedelta(days=1)))
+        self.assertNotIn(
+            self.testobj,
+            OrmP(date_value__lt=now - timedelta(days=1)))
+
         self.assertNotIn(
             self.testobj,
             OrmP(date_value__gt=now + timedelta(days=1)))
+        self.assertNotIn(
+            self.testobj,
+            OrmP(date_value__gte=now + timedelta(days=1)))
+        self.assertIn(
+            self.testobj,
+            OrmP(date_value__lte=now + timedelta(days=1)))
+        self.assertIn(
+            self.testobj,
+            OrmP(date_value__lt=now + timedelta(days=1)))
 
     def test_gte(self):
         self.assertTrue(OrmP(int_value__gte=20).eval(self.testobj))


### PR DESCRIPTION
This PR fixes all failing test cases, removing the final `expectedFailure` annotations on date/datetime and pk casting.

Also bumps the version to 1.0.0 to reflect a suggested public release