### PR TITLE
Add attribute and key following functionality

### DIFF
--- a/predicate/__init__.py
+++ b/predicate/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from .predicate import P
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'
 __all__ = ['P']
 

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -276,7 +276,7 @@ def get_values_list(obj, *lookups, **kwargs):
     flat = kwargs.pop('flat', False)
     if kwargs:
         raise TypeError('Unexpected keyword arguments to values_list: %s' %
-                        (list(kwargs),))
+                        kwargs.keys())
     if flat and len(lookups) > 1:
         raise TypeError("'flat' is not valid when values_list is called with more than one field.")  # nopep8
 

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -129,7 +129,7 @@ class LookupComponent(str):
         elif isinstance(obj, dict):
             try:
                 return obj[self]
-            except (KeyError, IndexError):
+            except KeyError:
                 pass
         raise LookupNotFound(self, obj)
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -19,6 +19,10 @@ class TestObj(Base):
     m2ms = models.ManyToManyField(
         'testapp.M2MModel', related_name='test_objs')
 
+    @property
+    def some_property(self):
+        return {'x': 'y'}
+
 
 class M2MModel(Base):
     pass


### PR DESCRIPTION
@jdavisp3 @cmason1978 @nosamanuel Supercedes #3. This PR updates lookup evaluation to apply to follow lookups across ordinary attributes and dictionary keys.

This significantly increases the flexibility of the library, though it breaks the invariant that `predicate.eval(obj)` iff `type(obj)._default_manager.filter(predicate).filter(pk=obj.pk).exists()`.  This invariant is maintained in cases where all the lookups only reference Django ORM fields and relations.

## Testing
I added unit tests for the desired behavior, and verified that all new lines of code are covered by the test suite with full branch coverage.