### PR TITLE
Add filter, get and exclude methods to P

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,23 @@ queryset filter statements:
 
     qs = MyModel.objects.filter(p)
 
+
+P objects also support ``QuerySet``-like filtering operations that can be
+applied to an arbitrary iterable: ``P.get(iterable)``, ``P.filter(iterable)``,
+and ``P.exclude(iterable)``:
+
+.. code-block:: python
+
+    model_instance = MyModel(some_field="hello there", age=21)
+    other_model_instance = MyModel(some_field="hello there", age=10)
+    p.filter([model_instance, other_model_instance]) == [model_instance]
+    >>> True
+    p.filter([model_instance, other_model_instance]) == model_instance
+    >>> True
+    p.filter([model_instance, other_model_instance]) == other_model_instance
+    >>> True
+
+
 If you have a situation where you want to use querysets and predicates based on
 the same conditions, it is far better to start with the predicate. Because of
 the way querysets assume a SQL context, it is non-trivial to reverse engineer

--- a/predicate/__init__.py
+++ b/predicate/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from .predicate import P
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'
 __all__ = ['P']
 

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -62,8 +62,18 @@ class P(Q):
     def filter(self, iterable):
         """
         Returns a filtered list of applying self to the elements of iterable.
+
+        This is a similar API to QuerySet.filter.
         """
         return filter(self.eval, iterable)
+
+    def exclude(self, iterable):
+        """
+        Returns a filtered list of applying ~self to the elements of iterable.
+
+        This is a similar API to QuerySet.exclude.
+        """
+        return filter((~self).eval, iterable)
 
     def get(self, iterable):
         """

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -5,6 +5,7 @@ try:
     from django.core.exceptions import FieldDoesNotExist
 except ImportError:  # Django <1.8
     from django.db.models.fields import FieldDoesNotExist
+from django.core.exceptions import MultipleObjectsReturned
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import Manager
@@ -57,6 +58,28 @@ class P(Q):
             return not ret
         else:
             return ret
+
+    def filter(self, iterable):
+        """
+        Returns a filtered list of applying self to the elements of iterable.
+        """
+        return filter(self.eval, iterable)
+
+    def get(self, iterable):
+        """
+        Gets the unique element of iterable that matches self.
+
+        This follows the QuerySet.get() api, raising ObjectDoesNotExist if no
+        element matches and MultipleObjectsReturned if multiple objects match.
+        """
+        filtered = self.filter(iterable)
+        if len(filtered) == 0:
+            raise ObjectDoesNotExist('Object matching query does not exist.')
+        elif len(filtered) > 1:
+            raise MultipleObjectsReturned(
+                'get() returned more than one object -- it returned %s!' % len(filtered))
+        else:
+            return filtered[0]
 
 
 class LookupNotFound(Exception):

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -570,3 +570,24 @@ class TestFilteringMethods(TestCase):
             set(TestObj.objects.filter(predicate)), {self.obj1, self.obj2})
         self.assertEqual(
             set(predicate.filter(self.objects)), {self.obj1, self.obj2})
+
+    def test_exclude(self):
+        predicate = OrmP(int_value=3)
+        self.assertEqual(
+            set(TestObj.objects.exclude(predicate)),
+            {self.obj1, self.obj2})
+        self.assertEqual(
+            set(predicate.exclude(self.objects)),
+            {self.obj1, self.obj2})
+
+        predicate = OrmP(int_value=1)
+        self.assertEqual(set(TestObj.objects.exclude(predicate)), {self.obj2})
+        self.assertEqual(set(predicate.exclude(self.objects)), {self.obj2})
+
+        predicate = OrmP(int_value=2)
+        self.assertEqual(set(TestObj.objects.exclude(predicate)), {self.obj1})
+        self.assertEqual(set(predicate.exclude(self.objects)), {self.obj1})
+
+        predicate = OrmP(int_value__in=[1, 2])
+        self.assertEqual(set(TestObj.objects.exclude(predicate)), set())
+        self.assertEqual(set(predicate.exclude(self.objects)), set())


### PR DESCRIPTION
@cmason1978 Refs #20. This PR adds `P.filter`, `P.get` and `P.exclude` methods. These behave essentially like the corresponding `QuerySet` methods.

I added tests that check there's a tight correspondence with the queryset methods, which pass with full coverage on the added code.