### PR TITLE
Fix date casting

### DIFF
--- a/predicate/__init__.py
+++ b/predicate/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from .predicate import P
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 __all__ = ['P']
 

--- a/predicate/lookup_utils.py
+++ b/predicate/lookup_utils.py
@@ -107,15 +107,24 @@ class In(LookupQueryEvaluator):
         return self._cast(lhs)
 
 
+def is_date(obj):
+    """
+    Returns True if obj is a date object proper.
+
+    This is a bit tricky because datetime inherits from date.
+    """
+    return isinstance(obj, datetime.date) and not isinstance(obj, datetime.datetime)
+
+
 class DateCastMixin(object):
     def cast_lhs(self, lhs):
-        if isinstance(lhs, datetime.datetime) and isinstance(self.rhs, datetime.date):
+        if isinstance(lhs, datetime.datetime) and is_date(self.rhs):
             lhs = lhs.date()
         return lhs
 
     def cast_rhs(self, lhs):
         rhs = self.rhs
-        if isinstance(rhs, datetime.datetime) and isinstance(lhs, datetime.date):
+        if isinstance(rhs, datetime.datetime) and is_date(lhs):
             rhs = rhs.date()
         return rhs
 

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -265,11 +265,13 @@ class RelationshipFollowTest(TestCase):
 class ComparisonFunctionsTest(TestCase):
 
     def setUp(self):
+        self.date_obj = date(2016, 2, 16)
+        self.datetime_obj = datetime(2016, 2, 16, 16, 24, 26, 688247)
         self.testobj = TestObj.objects.create(
             char_value="hello world",
             int_value=50,
-            date_value=date.today(),
-            datetime_value=datetime.now(),
+            date_value=self.date_obj,
+            datetime_value=self.datetime_obj,
         )
 
     def test_exact(self):
@@ -307,59 +309,57 @@ class ComparisonFunctionsTest(TestCase):
         Tests that the Django ORM casting rules are obeyed in filtering by
         dates and times.
         """
-        date_obj = date.today()
-        datetime_obj = datetime.now()
         self.assertIn(
             self.testobj,
-            OrmP(datetime_value__gt=date_obj - timedelta(days=1)))
+            OrmP(datetime_value__gt=self.date_obj - timedelta(days=1)))
         self.assertIn(
             self.testobj,
-            OrmP(datetime_value__gte=date_obj - timedelta(days=1)))
+            OrmP(datetime_value__gte=self.date_obj - timedelta(days=1)))
         self.assertNotIn(
             self.testobj,
-            OrmP(datetime_value__lte=date_obj - timedelta(days=1)))
+            OrmP(datetime_value__lte=self.date_obj - timedelta(days=1)))
         self.assertNotIn(
             self.testobj,
-            OrmP(datetime_value__lt=date_obj - timedelta(days=1)))
+            OrmP(datetime_value__lt=self.date_obj - timedelta(days=1)))
 
         self.assertNotIn(
             self.testobj,
-            OrmP(datetime_value__gt=date_obj + timedelta(days=1)))
+            OrmP(datetime_value__gt=self.date_obj + timedelta(days=1)))
         self.assertNotIn(
             self.testobj,
-            OrmP(datetime_value__gte=date_obj + timedelta(days=1)))
+            OrmP(datetime_value__gte=self.date_obj + timedelta(days=1)))
         self.assertIn(
             self.testobj,
-            OrmP(datetime_value__lte=date_obj + timedelta(days=1)))
+            OrmP(datetime_value__lte=self.date_obj + timedelta(days=1)))
         self.assertIn(
             self.testobj,
-            OrmP(datetime_value__lt=date_obj + timedelta(days=1)))
+            OrmP(datetime_value__lt=self.date_obj + timedelta(days=1)))
 
         self.assertIn(
             self.testobj,
-            OrmP(date_value__gt=datetime_obj - timedelta(days=1)))
+            OrmP(date_value__gt=self.datetime_obj - timedelta(days=1)))
         self.assertIn(
             self.testobj,
-            OrmP(date_value__gte=datetime_obj - timedelta(days=1)))
+            OrmP(date_value__gte=self.datetime_obj - timedelta(days=1)))
         self.assertNotIn(
             self.testobj,
-            OrmP(date_value__lte=datetime_obj - timedelta(days=1)))
+            OrmP(date_value__lte=self.datetime_obj - timedelta(days=1)))
         self.assertNotIn(
             self.testobj,
-            OrmP(date_value__lt=datetime_obj - timedelta(days=1)))
+            OrmP(date_value__lt=self.datetime_obj - timedelta(days=1)))
 
         self.assertNotIn(
             self.testobj,
-            OrmP(date_value__gt=datetime_obj + timedelta(days=1)))
+            OrmP(date_value__gt=self.datetime_obj + timedelta(days=1)))
         self.assertNotIn(
             self.testobj,
-            OrmP(date_value__gte=datetime_obj + timedelta(days=1)))
+            OrmP(date_value__gte=self.datetime_obj + timedelta(days=1)))
         self.assertIn(
             self.testobj,
-            OrmP(date_value__lte=datetime_obj + timedelta(days=1)))
+            OrmP(date_value__lte=self.datetime_obj + timedelta(days=1)))
         self.assertIn(
             self.testobj,
-            OrmP(date_value__lt=datetime_obj + timedelta(days=1)))
+            OrmP(date_value__lt=self.datetime_obj + timedelta(days=1)))
 
     def test_gte(self):
         self.assertTrue(OrmP(int_value__gte=20).eval(self.testobj))

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -335,6 +335,19 @@ class ComparisonFunctionsTest(TestCase):
             self.testobj,
             OrmP(datetime_value__lt=self.date_obj + timedelta(days=1)))
 
+        self.assertNotIn(
+            self.testobj,
+            OrmP(datetime_value__gt=self.datetime_obj + timedelta(seconds=1)))
+        self.assertNotIn(
+            self.testobj,
+            OrmP(datetime_value__gte=self.datetime_obj + timedelta(seconds=1)))
+        self.assertIn(
+            self.testobj,
+            OrmP(datetime_value__lte=self.datetime_obj + timedelta(seconds=1)))
+        self.assertIn(
+            self.testobj,
+            OrmP(datetime_value__lt=self.datetime_obj + timedelta(seconds=1)))
+
         self.assertIn(
             self.testobj,
             OrmP(date_value__gt=self.datetime_obj - timedelta(days=1)))

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -307,59 +307,59 @@ class ComparisonFunctionsTest(TestCase):
         Tests that the Django ORM casting rules are obeyed in filtering by
         dates and times.
         """
-        today = date.today()
-        now = datetime.now()
+        date_obj = date.today()
+        datetime_obj = datetime.now()
         self.assertIn(
             self.testobj,
-            OrmP(datetime_value__gt=today - timedelta(days=1)))
+            OrmP(datetime_value__gt=date_obj - timedelta(days=1)))
         self.assertIn(
             self.testobj,
-            OrmP(datetime_value__gte=today - timedelta(days=1)))
+            OrmP(datetime_value__gte=date_obj - timedelta(days=1)))
         self.assertNotIn(
             self.testobj,
-            OrmP(datetime_value__lte=today - timedelta(days=1)))
+            OrmP(datetime_value__lte=date_obj - timedelta(days=1)))
         self.assertNotIn(
             self.testobj,
-            OrmP(datetime_value__lt=today - timedelta(days=1)))
+            OrmP(datetime_value__lt=date_obj - timedelta(days=1)))
 
         self.assertNotIn(
             self.testobj,
-            OrmP(datetime_value__gt=today + timedelta(days=1)))
+            OrmP(datetime_value__gt=date_obj + timedelta(days=1)))
         self.assertNotIn(
             self.testobj,
-            OrmP(datetime_value__gte=today + timedelta(days=1)))
+            OrmP(datetime_value__gte=date_obj + timedelta(days=1)))
         self.assertIn(
             self.testobj,
-            OrmP(datetime_value__lte=today + timedelta(days=1)))
+            OrmP(datetime_value__lte=date_obj + timedelta(days=1)))
         self.assertIn(
             self.testobj,
-            OrmP(datetime_value__lt=today + timedelta(days=1)))
+            OrmP(datetime_value__lt=date_obj + timedelta(days=1)))
 
         self.assertIn(
             self.testobj,
-            OrmP(date_value__gt=now - timedelta(days=1)))
+            OrmP(date_value__gt=datetime_obj - timedelta(days=1)))
         self.assertIn(
             self.testobj,
-            OrmP(date_value__gte=now - timedelta(days=1)))
+            OrmP(date_value__gte=datetime_obj - timedelta(days=1)))
         self.assertNotIn(
             self.testobj,
-            OrmP(date_value__lte=now - timedelta(days=1)))
+            OrmP(date_value__lte=datetime_obj - timedelta(days=1)))
         self.assertNotIn(
             self.testobj,
-            OrmP(date_value__lt=now - timedelta(days=1)))
+            OrmP(date_value__lt=datetime_obj - timedelta(days=1)))
 
         self.assertNotIn(
             self.testobj,
-            OrmP(date_value__gt=now + timedelta(days=1)))
+            OrmP(date_value__gt=datetime_obj + timedelta(days=1)))
         self.assertNotIn(
             self.testobj,
-            OrmP(date_value__gte=now + timedelta(days=1)))
+            OrmP(date_value__gte=datetime_obj + timedelta(days=1)))
         self.assertIn(
             self.testobj,
-            OrmP(date_value__lte=now + timedelta(days=1)))
+            OrmP(date_value__lte=datetime_obj + timedelta(days=1)))
         self.assertIn(
             self.testobj,
-            OrmP(date_value__lt=now + timedelta(days=1)))
+            OrmP(date_value__lt=datetime_obj + timedelta(days=1)))
 
     def test_gte(self):
         self.assertTrue(OrmP(int_value__gte=20).eval(self.testobj))


### PR DESCRIPTION
This PR fixes a bug found by @sean-adler. 

## What happened?

Django has some odd casting semantics around date and datetime comparisons, where comparing a `DateTimeField` against a date causes the date to get cast to a time when executing the SQL query. `P` tried to address this in the `DateTimeCastMixin` by a casting rule. Unfortunately, I did direct instance checks for whether the passed object is an instance of `datetime.date`, and it turns out that `datetime.date` is the parent class of `datetime.datetime`.

## Testing
I added a test checking that datetime filtering works as expected against datetime objects. It failed before 0b55a9482973911dc5d3de120c24e858799a0f8b, and passes afterwards. I also validated the example dictionary @sean-adler gave me:
```
(Pdb) created_dict = {u'created_at': datetime(2016, 2, 16, 4, 43, 23, 651460)}
(Pdb) dt = datetime(2016, 2, 16, 5, 0)
(Pdb) 
(Pdb) P(created_at__gt=dt).filter([created_dict])
[]
(Pdb) P(created_at=dt).filter([created_dict])    
[]
(Pdb) P(created_at__lt=dt).filter([created_dict])
[{u'created_at': datetime.datetime(2016, 2, 16, 4, 43, 23, 651460)}]
```
On the master branch, this has the following nonsensical behavior:
```
(Pdb) created_dict = {u'created_at': datetime(2016, 2, 16, 4, 43, 23, 651460)}
(Pdb) dt = datetime(2016, 2, 16, 5, 0)
(Pdb) 
(Pdb) P(created_at__gt=dt).filter([created_dict])
[]
(Pdb) P(created_at=dt).filter([created_dict])
[]
(Pdb) P(created_at__lt=dt).filter([created_dict])
[]
```