### PR TITLE
Add debugging contextmanger

### DIFF
--- a/predicate/__init__.py
+++ b/predicate/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 from .predicate import P
 
-__version__ = '1.2.2'
+__version__ = '1.3.0'
 __all__ = ['P']
 

--- a/predicate/debug.py
+++ b/predicate/debug.py
@@ -1,0 +1,51 @@
+from contextlib import contextmanager
+
+from nose.tools import assert_equal
+
+from predicate import P
+
+original_eval = P.eval
+
+
+def orm_eval(predicate, instance):
+    """
+    Implementation of P semantics that asserts the ORM and P have the same
+    semantics. Also validates negation logic on the provided query
+
+    This is much slower than P.eval, but can be used for debugging
+    discrepancies with the ORM, or validating there are none.
+    """
+    manager = type(instance)._default_manager
+
+    orm_value = manager.filter(predicate, pk=instance.pk).exists()
+    super_value = original_eval(predicate, instance)
+    assert_equal(orm_value, super_value)
+
+    return super_value
+
+
+class OrmP(P):
+    """
+    Version of P class that asserts the invariants of the orm_eval method.
+    """
+    def eval(self, instance):
+        return orm_eval(self, instance)
+
+
+@contextmanager
+def patch_with_orm_eval():
+    """
+    Patches P.eval with the orm_eval version for debugging and validation.
+
+    Requires the `mock` package.  Usage:
+        from predicate.debug import patch_with_orm_eval
+        with patch_with_orm_eval():
+            some_code_where_calling_P()
+
+    This will evaluate both in-memory, and via a roundtrip to the database, so
+    should not be used in production code.
+    """
+    from mock import patch
+    with patch.object(P, eval=orm_eval):
+        yield
+

--- a/predicate/debug.py
+++ b/predicate/debug.py
@@ -45,7 +45,8 @@ def patch_with_orm_eval():
     This will evaluate both in-memory, and via a roundtrip to the database, so
     should not be used in production code.
     """
-    from mock import patch
-    with patch.object(P, eval=orm_eval):
+    try:
+        P.eval = orm_eval
         yield
-
+    finally:
+        P.eval = original_eval

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ coverage
 django-nose==1.4.2
 nose==1.3.7
 psycopg2
+mock


### PR DESCRIPTION
@ChrisBeaumont: This PR adds some debugging/validation capability to help validate that `predicate.P` behaves identically to `Q` in test suites.

## Changes
I moved `OrmP` into a different module, and added a context manager that monkeypatches `P.eval` with a version that checks the invariant previously checked by `OrmP`. 

Factoring that out into a method allowed me to avoid some infinite recursion issues I ran into trying to add negation invariants to `OrmP` before. I tried adding those invariants in https://github.com/lucaswiman/django-predicate/commit/2f2a99ceea1ef1f79a24325cf2472bdd9d1a4e08, but they broke some tests. For now, it's probably wise to consider negation a "beta" feature, and use the `patch_with_orm_eval` in tests to validate the behavior of `P.eval`.

Bug reports for any discrepancies found would be greatly appreciated!

## Usage
```python
from predicate.debug import patch_with_orm_eval
with patch_with_orm_eval():
    some_code_involving_P()
```
This will fail with an `AssertionError` if any discrepancies are found with the ORM behavior of the ORM. Note that though `P.eval` _can_ filter based on computed properties, the ORM invariants will fail with some kind of "field not found" or "invalid lookup" errors, so the `patch_with_orm_eval` method will only work on genuine Django model fields.