### PR TITLE
Wrap Q() instances in P() during tree traversal

### DIFF
--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -25,6 +25,8 @@ def eval_wrapper(children, connector):
     for child in children:
         if isinstance(child, P):
             yield child
+        elif isinstance(child, Q):
+            yield P._new_instance(child.children, child.connector, child.negated)
         elif isinstance(child, tuple):
             lookup, value = child
             lookups[lookup] = value

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -803,6 +803,15 @@ class TestFilteringMethods(TestCase):
         self.assertEqual(set(TestObj.objects.exclude(predicate)), set())
         self.assertEqual(set(predicate.exclude(self.objects)), set())
 
+    def test_nested_q(self):
+        predicate = OrmP(Q(int_value=1))
+        self.assertEqual(set(TestObj.objects.filter(predicate)), {self.obj1})
+        self.assertEqual(set(predicate.filter(self.objects)), {self.obj1})
+
+        predicate = OrmP(Q(Q(int_value=1)))
+        self.assertEqual(set(TestObj.objects.filter(predicate)), {self.obj1})
+        self.assertEqual(set(predicate.filter(self.objects)), {self.obj1})
+
 
 class TestDebugTools(TestCase):
     def setUp(self):


### PR DESCRIPTION
I'd like to be able to use `Q()` everywhere, and wrap it in `P()` only in situations in which local evaluation will actually happen. It makes the imports cleaner. To that end, it's nice to be able to say `P(Q())` and have it "just work".