### PR TITLE
Fix bug with same lookup path passed more than once

### DIFF
--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -1,5 +1,7 @@
 import itertools
 
+from django.utils.tree import Node
+
 try:
     from django.core.exceptions import FieldDoesNotExist
 except ImportError:  # Django <1.8
@@ -61,6 +63,39 @@ class P(Q):
             return not ret
         else:
             return ret
+
+    def add(self, data, conn_type, squash=True):
+        """
+        Adapted from `django.utils.tree.Node.add`` to handle the case of
+        repeating the same lookup.  This isn't well handled by LookupTree, so we
+        need to specially handle cases like ``P(x=1) | P(x=2)``.
+        """
+        if data in self.children:
+            return data
+        if not squash:
+            self.children.append(data)
+            return data
+        if self.connector == conn_type:
+            if (isinstance(data, Node) and not data.negated
+                    and (data.connector == conn_type or len(data) == 1)):
+                for child in data.children:
+                    self.add(child, conn_type, squash=squash)
+                return self
+            else:
+                if isinstance(data, tuple) and any(
+                        isinstance(child, tuple) and child[0] == data[0]
+                        for child in self.children):
+                    # Special handling for cases where we already have this lookup.
+                    self.add(type(self)(data), conn_type, squash=False)
+                else:
+                    self.children.append(data)
+                return data
+        else:
+            obj = self._new_instance(self.children, self.connector,
+                                     self.negated)
+            self.connector = conn_type
+            self.children = [obj, data]
+            return data
 
     def __invert__(self):
         if len(self.children) == 1:

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -571,6 +571,8 @@ class TestBooleanOperations(TestCase):
         self.assertTrue(pand1.eval(self.testobj))
         self.assertFalse(pand2.eval(self.testobj))
 
+        self.assertNotIn(self.testobj, OrmP(int_value=20) & OrmP(int_value=50))
+
     def test_or(self):
         self.testobj.m2ms.create(int_value=10)
         p1 = OrmP(char_value__contains='hello', int_value=50)
@@ -590,6 +592,9 @@ class TestBooleanOperations(TestCase):
         self.assertIn(self.testobj, OrmP(m2ms__int_value=10) | OrmP(char_value='hello world'))
         self.assertIn(self.testobj, OrmP(m2ms__int_value=10) | OrmP(char_value='something else'))
         self.assertIn(self.testobj, OrmP(char_value='something else') | OrmP(m2ms__int_value=10))
+
+        self.assertIn(self.testobj, OrmP(int_value__in=[50, 20]))
+        self.assertIn(self.testobj, OrmP(int_value=50) | OrmP(int_value=20))
 
     def test_not(self):
         self.assertIn(self.testobj, OrmP(int_value=self.testobj.int_value))


### PR DESCRIPTION
cc @staticshock Fixes #31. The bug is that I was modeling lookups as a dict-based tree where the paths to leaf nodes are the given lookup paths, and the values at the nodes are what the lookup should match against. This means that adding the same lookup twice with different values causes the first one to get overridden.

I fixed this via a hack to encapsulate children already present in a `P` object by overriding `Node.add`.  I'm not completely satisfied with this approach, since the query evaluation plan in the ORM can consider lookup tuples in the same `Node.children` list to have a subtly different meaning than two combined nodes. In particular, I think the approach here could cause some extraneous joins to be constructed, and might change the meaning of some queries.

I'm currently working on a more principled approach that models a predicate as a set of constraints, and shouldn't be susceptible to this issue.  In the mean time, this hack fixes a fairly serious bug.  The full test suite passes, and I added some extra assertions that reproduce the bug you found in #31.